### PR TITLE
Add null param check for StandardPodUtils and Unit test

### DIFF
--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/StandardPodUtils.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/StandardPodUtils.java
@@ -36,6 +36,10 @@ public class StandardPodUtils implements PodUtils {
     private Supplier<Pod> current;
 
     public StandardPodUtils(KubernetesClient client) {
+        if (client == null) {
+            throw new IllegalArgumentException("Must provide an instance of KubernetesClient");
+        }
+
         this.client = client;
         this.hostName = System.getenv(HOSTNAME);
         this.current = LazilyInstantiate.using(() -> internalGetPod());

--- a/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/StandardPodUtilsTest.java
+++ b/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/StandardPodUtilsTest.java
@@ -1,0 +1,29 @@
+/*
+ *     Copyright (C) 2016 to the original authors.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *             http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package org.springframework.cloud.kubernetes;
+
+import org.junit.Test;
+
+public class StandardPodUtilsTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorThrowsIllegalArgumentExceptionWhenKubeClientNull() {
+        // expect an IllegalArgumentException if KubernetesClient argument is
+        // null
+        new StandardPodUtils(null);
+    }
+
+}


### PR DESCRIPTION
A small start to #26!

Added a null check in StandardPodUtils, since an instance with a null Kube client would have limited usefulness and we should protect developers from a configuration error. If a developer decides not to use a KubernetesClient, they should probably implement the PodUtils interface and supply an alternate implementation instead of passing null to StandardPodUtils.

Holding off on additional tests for StandardPodUtils for now, since it will be tricky to simulate running inside a pod because of the file system checks, and we can't guarantee that the test is running outside of a pod.