### PR TITLE
#26: First draft of integration tests example.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 		<!-- Maven Plugin Versions -->
 		<maven-compiler-plugin.version>3.5</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+		<maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
 		<maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
 		<fabric8.maven.plugin.version>3.2.28</fabric8.maven.plugin.version>
 		<gmavenplus-plugin.version>1.2</gmavenplus-plugin.version>

--- a/spring-cloud-kubernetes-dependencies/pom.xml
+++ b/spring-cloud-kubernetes-dependencies/pom.xml
@@ -14,6 +14,8 @@
 	<name>Spring Cloud Kubernetes :: Dependencies</name>
 	<description>Spring Cloud Kubernetes Dependencies</description>
 	<properties>
+		<arquillian.version>1.1.12.Final</arquillian.version>
+		<arquillian-cube.version>1.0.0.Alpha20</arquillian-cube.version>
 		<kubernetes-client.version>2.2.0</kubernetes-client.version>
 		<mockwebserver.version>0.0.12</mockwebserver.version>
 		<spock-spring.version>1.0-groovy-2.3</spock-spring.version>
@@ -104,6 +106,31 @@
 			</dependency>
 
 			<!-- Testing Dependencies -->
+			<dependency>
+				<groupId>org.jboss.arquillian.junit</groupId>
+				<artifactId>arquillian-junit-standalone</artifactId>
+				<version>${arquillian.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.arquillian.cube</groupId>
+				<artifactId>arquillian-cube-requirement</artifactId>
+				<version>${arquillian-cube.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.arquillian.cube</groupId>
+				<artifactId>arquillian-cube-kubernetes</artifactId>
+				<version>${arquillian-cube.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.arquillian.cube</groupId>
+				<artifactId>arquillian-cube-openshift</artifactId>
+				<version>${arquillian-cube.version}</version>
+				<scope>test</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>io.fabric8</groupId>
 				<artifactId>mockwebserver</artifactId>

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
@@ -1,0 +1,11 @@
+# Hello World Example
+
+This is a `Hello World` spring cloud application.
+
+To run the application on Kubernetes:
+
+     mvn clean package fabric8:build fabric8:deploy fabric8:start
+     
+To run the integration tests:     
+
+	mvn clean install -Pintegration

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/pom.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>spring-cloud-kubernetes-examples</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>0.2.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.springframework.cloud</groupId>
+	<artifactId>kubernetes-hello-world</artifactId>
+	<name>Spring Cloud Kubernetes :: Examples :: Hello World</name>
+	<description>A simple example that demonstrates how to build and test a basic spring cloud kubernetes app</description>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<type>pom</type>
+				<scope>import</scope>
+				<version>${spring-boot.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-kubernetes-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!--
+			We need that(actuator) so that it can be used in readiness probes.
+			Readiness checks are needed by arquillian, so that it
+			knows when to run the actual test.
+		-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<!-- Testing -->
+		<dependency>
+			<groupId>org.jboss.arquillian.junit</groupId>
+			<artifactId>arquillian-junit-standalone</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.arquillian.cube</groupId>
+			<artifactId>arquillian-cube-requirement</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.arquillian.cube</groupId>
+			<artifactId>arquillian-cube-kubernetes</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring-boot.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<!--skip deploy -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>${maven-deploy-plugin.version}</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<skipTests>true</skipTests>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>fabric8-maven-plugin</artifactId>
+				<version>${fabric8.maven.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>fmp</id>
+						<goals>
+							<goal>resource</goal>
+							<goal>helm</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.fabric8</groupId>
+						<artifactId>fabric8-maven-plugin</artifactId>
+						<version>${fabric8.maven.plugin.version}</version>
+						<executions>
+							<execution>
+								<id>fmp</id>
+								<goals>
+									<goal>resource</goal>
+									<goal>helm</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>integration</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.fabric8</groupId>
+						<artifactId>fabric8-maven-plugin</artifactId>
+						<version>${fabric8.maven.plugin.version}</version>
+						<executions>
+							<execution>
+								<id>fmp</id>
+								<goals>
+									<goal>resource</goal>
+									<goal>helm</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>${maven-failsafe-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>run-integration-tests</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>integration-test</goal>
+									<goal>verify</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<skipTests>false</skipTests>
+							<skipITs>false</skipITs>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/java/org/springframework/cloud/kubernetes/examples/App.java
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/java/org/springframework/cloud/kubernetes/examples/App.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016 to the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.springframework.cloud.kubernetes.examples;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ *
+ */
+@SpringBootApplication
+public class App {
+
+    public static void main(String[] args) {
+        SpringApplication.run(App.class, args);
+    }
+
+}

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/java/org/springframework/cloud/kubernetes/examples/HelloController.java
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/java/org/springframework/cloud/kubernetes/examples/HelloController.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.kubernetes.examples;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+	@RequestMapping("/")
+	public String hello() {
+		return "Hello World";
+	}
+
+}

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/resources/application.properties
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=hello-world-example

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/test/java/org/springframework/cloud/kubernetes/examples/HelloWorldIT.java
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/test/java/org/springframework/cloud/kubernetes/examples/HelloWorldIT.java
@@ -1,0 +1,39 @@
+package org.springframework.cloud.kubernetes.examples;
+
+
+import org.arquillian.cube.kubernetes.annotations.PortForward;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URL;
+
+import javax.inject.Named;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Service;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresKubernetes
+public class HelloWorldIT {
+
+	@ArquillianResource
+	@Named("kubernetes-hello-world") //The service name is "${project.artifactId}".substring(0,23)
+	@PortForward
+	URL url;
+
+	@Test
+	public void service_should_be_accessible() throws IOException {
+		OkHttpClient client = new OkHttpClient();
+		Request request = new Request.Builder().get().url(url).build();
+		Response response = client.newCall(request).execute();
+		Assert.assertTrue(response.isSuccessful());
+	}
+}

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/test/resources/arquillian.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/test/resources/arquillian.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			xmlns="http://jboss.org/schema/arquillian"
+			xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+	<extension qualifier="kubernetes">
+	</extension>
+</arquillian>

--- a/spring-cloud-kubernetes-examples/pom.xml
+++ b/spring-cloud-kubernetes-examples/pom.xml
@@ -17,6 +17,7 @@
 
 	<modules>
 		<module>kubernetes-reload-example</module>
+		<module>kubernetes-hello-world-example</module>
 	</modules>
 
 


### PR DESCRIPTION
This pull request adds an example which demonstrates a simple integration-test.

The test is using [arquillian cube for kubernetes](https://github.com/arquillian/arquillian-cube/blob/master/docs/kubernetes.adoc) to install the app in an isolated namesapce and then lookup and access the actual service (via portforwarding).

Note: The pull request introduces a snapshot dependency on arquillian-cube, but hopefully will be replaced with a released version shortly.