### PR TITLE
POM name is too long to setup the Deployment & Service kubernetes name

### DIFF
--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-undertow</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
@@ -123,6 +123,18 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<enricher>
+								<config>
+									<fmp-controller>
+										<name>spring-cloud-reload</name>
+								    </fmp-controller>
+									<fmp-service>
+										<name>spring-cloud-reload</name>
+									</fmp-service>
+								</config>
+							</enricher>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
@@ -11,8 +11,8 @@
 
     <artifactId>spring-cloud-kubernetes-example-reload</artifactId>
 
-    <name>Spring Cloud Kubernetes :: Examples :: Reload</name>
-    <description>Example demostrating how to use the configuration reload feature.</description>
+    <name>Spring Cloud Kubernetes :: Examples :: Reload ConfigMap</name>
+    <description>Example demonstrating how to use the configuration reload feature.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -31,16 +31,14 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-kubernetes-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
+		<dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-actuator</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -58,6 +56,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+			<version>${project.version}</version>
 		</dependency>
 
         <dependency>
@@ -105,6 +104,18 @@
                         </goals>
                     </execution>
                 </executions>
+				<configuration>
+					<enricher>
+						<config>
+							<fmp-controller>
+								<name>spring-cloud-reload</name>
+							</fmp-controller>
+							<fmp-service>
+								<name>spring-cloud-reload</name>
+							</fmp-service>
+						</config>
+					</enricher>
+				</configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- POM name is too long to setup the Deployment & Service kubernetes name as it will generate this error when populated by f-m-p plugin

```
[ERROR] Failed to execute goal io.fabric8:fabric8-maven-plugin:3.2.28:deploy (default-cli) on project spring-cloud-kubernetes-example-reload: Failed to create Deployment from kubernetes.yml. io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://192.168.99.100:8443/apis/extensions/v1beta1/namespaces/default/deployments. Message: Deployment.extensions "spring-cloud-kubernetes-" is invalid: metadata.name: Invalid value: "spring-cloud-kubernetes-": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)* (e.g. 'example.com'). Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=metadata.name, message=Invalid value: "spring-cloud-kubernetes-": 
``` 