### PR TITLE
Add java test case covering Ribbon

### DIFF
--- a/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/RibbonFallbackTest.java
+++ b/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/RibbonFallbackTest.java
@@ -25,6 +25,8 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.server.mock.KubernetesServer;
 import io.fabric8.mockwebserver.DefaultMockServer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -65,6 +67,9 @@ public class RibbonFallbackTest {
 
 	public static KubernetesClient mockClient;
 
+	private static final Log LOG = LogFactory.getLog(RibbonFallbackTest.class);
+
+
 	@Autowired
 	RestTemplate restTemplate;
 
@@ -92,6 +97,7 @@ public class RibbonFallbackTest {
 		mockEndpoint.expect().get().withPath("/greeting").andReturn(200, "Hello from A").once();
 		String response = restTemplate.getForObject("http://testapp/greeting", String.class);
 		Assert.assertEquals("Hello from A",response);
+		LOG.debug(">>>>>>>>>> TEST 1 <<<<<<<<<<<<<");
 	}
 
 	@Test
@@ -104,6 +110,7 @@ public class RibbonFallbackTest {
 		catch (Exception e) {
 			// No endpoint is available anymore and Ribbon list is empty
 			Assert.assertEquals("No instances available for testapp",e.getMessage());
+			LOG.debug(">>>>>>>>>> TEST 2 <<<<<<<<<<<<<");
 		}
 	}
 
@@ -117,6 +124,7 @@ public class RibbonFallbackTest {
 		mockEndpoint.expect().get().withPath("/greeting").andReturn(200, "Hello from A").once();
 		String response = restTemplate.getForObject("http://testapp/greeting", String.class);
 		Assert.assertEquals("Hello from A",response);
+		LOG.debug(">>>>>>>>>> TEST 3 <<<<<<<<<<<<<");
 	}
 
 	public static Endpoints newEndpoint(String name, String namespace, DefaultMockServer mockServer) {

--- a/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/RibbonFallbackTest.java
+++ b/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/RibbonFallbackTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2016 to the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.kubernetes.ribbon;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.EndpointsBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import io.fabric8.mockwebserver.DefaultMockServer;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.Assert.fail;
+
+;
+
+/**
+ * @author <a href="mailto:cmoullia@redhat.com">Charles Moulliard</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestApplication.class,
+                properties = {
+	"spring.application.name=testapp",
+	"spring.cloud.kubernetes.client.namespace=testns",
+	"spring.cloud.kubernetes.client.trustCerts=true",
+	"spring.cloud.kubernetes.config.namespace=testns"})
+@EnableAutoConfiguration
+@EnableDiscoveryClient
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class RibbonFallbackTest {
+
+	@ClassRule
+	public static KubernetesServer mockServer = new KubernetesServer();
+
+	public static DefaultMockServer mockEndpoint;
+
+	public static KubernetesClient mockClient;
+
+	@Autowired
+	RestTemplate restTemplate;
+
+	@BeforeClass
+	public static void setUpBefore() throws Exception {
+		mockClient = mockServer.getClient();
+
+		//Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+
+		mockEndpoint = new DefaultMockServer(false);
+		mockEndpoint.start();
+	}
+
+	@Test
+	public void test1DiscoverCallGreetingEndpoint() throws IOException {
+		// Register an endpoint
+		mockServer.expect().get()
+			      .withPath("/api/v1/namespaces/testns/endpoints/testapp")
+			      .andReturn(200, newEndpoint("testapp-a","testns", mockEndpoint)).once();
+
+		mockEndpoint.expect().get().withPath("/greeting").andReturn(200, "Hello from A").once();
+		String response = restTemplate.getForObject("http://testapp/greeting", String.class);
+		Assert.assertEquals("Hello from A",response);
+	}
+
+	@Test
+	public void test2DontDiscoverEndpointGreeting() {
+		try {
+			Thread.sleep(1000);
+			restTemplate.getForObject("http://testapp/greeting", String.class);
+			fail("My method didn't throw when I expected it to");
+		}
+		catch (Exception e) {
+			// No endpoint is available anymore and Ribbon list is empty
+			Assert.assertEquals("No instances available for testapp",e.getMessage());
+		}
+	}
+
+	@Test
+	public void test3RediscoverGreetingEndpoint() throws Exception {
+		mockServer.expect().get()
+			.withPath("/api/v1/namespaces/testns/endpoints/testapp")
+			.andReturn(200, newEndpoint("testapp-a","testns", mockEndpoint)).always();
+		// Sleep thread to let Ribbon to discover the endpoint after RefreshTime is passed (= 500ms)
+		Thread.sleep(1000);
+		mockEndpoint.expect().get().withPath("/greeting").andReturn(200, "Hello from A").once();
+		String response = restTemplate.getForObject("http://testapp/greeting", String.class);
+		Assert.assertEquals("Hello from A",response);
+	}
+
+	public static Endpoints newEndpoint(String name, String namespace, DefaultMockServer mockServer) {
+		return new EndpointsBuilder()
+			        .withNewMetadata()
+			          .withName(name)
+			          .withNamespace(namespace)
+			          .endMetadata()
+			        .addNewSubset()
+			          .addNewAddress().withIp(mockServer.getHostName()).endAddress()
+			          .addNewPort("http",mockServer.getPort(),"http")
+			        .endSubset()
+			        .build();
+	}
+
+}

--- a/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/RibbonTest.java
+++ b/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/RibbonTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2016 to the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.kubernetes.ribbon;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.EndpointsBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author <a href="mailto:cmoullia@redhat.com">Charles Moulliard</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestApplication.class,
+                properties = {
+	"spring.application.name=testapp",
+	"spring.cloud.kubernetes.client.namespace=testns",
+	"spring.cloud.kubernetes.client.trustCerts=true",
+	"spring.cloud.kubernetes.config.namespace=testns"})
+@EnableAutoConfiguration
+@EnableDiscoveryClient
+public class RibbonTest {
+
+	@ClassRule
+	public static KubernetesServer server = new KubernetesServer();
+
+	@ClassRule
+	public static KubernetesServer mockEndpointA = new KubernetesServer(false);
+
+	@ClassRule
+	public static KubernetesServer mockEndpointB = new KubernetesServer(false);
+
+	public static KubernetesClient mockClient;
+
+	@Autowired
+	RestTemplate restTemplate;
+
+	@BeforeClass
+	public static void setUpBefore() throws Exception {
+		mockClient = server.getClient();
+
+		//Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+
+		//Configured
+		server.expect().get().withPath("/api/v1/namespaces/testns/endpoints/testapp").andReturn(200, new EndpointsBuilder()
+			.withNewMetadata()
+			.withName("testapp-a")
+			.endMetadata()
+			.addNewSubset()
+			.addNewAddress().withIp(mockEndpointA.getMockServer().getHostName()).endAddress()
+			.addNewPort("http", mockEndpointA.getMockServer().getPort(), "http")
+			.endSubset()
+			.addNewSubset()
+			.addNewAddress().withIp(mockEndpointB.getMockServer().getHostName()).endAddress()
+			.addNewPort("http", mockEndpointB.getMockServer().getPort(), "http")
+			.endSubset()
+			.build()).always();
+
+		mockEndpointA.expect().get().withPath("/greeting").andReturn(200, "Hello from A").always();
+		mockEndpointB.expect().get().withPath("/greeting").andReturn(200, "Hello from B").always();
+	}
+
+	@Test
+	public void testGreetingEndpoint() {
+		List<String> greetings = new ArrayList<>();
+		for (int i = 0; i < 2 ; i++) {
+			greetings.add(restTemplate.getForObject("http://testapp/greeting", String.class));
+		}
+		greetings.contains("Hello from A");
+		greetings.contains("Hello from B");
+	}
+
+}

--- a/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/TestApplication.java
+++ b/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/TestApplication.java
@@ -1,0 +1,39 @@
+package org.springframework.cloud.kubernetes.ribbon;
+
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author <a href="mailto:cmoullia@redhat.com">Charles Moulliard</a>
+ */
+@SpringBootApplication
+public class TestApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(TestApplication.class, args);
+	}
+
+	@LoadBalanced
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+
+
+	// TODO - Should be refactored when we will fix how the Default client could be created out of the box
+	@Bean
+	public IClientConfig ribbonClientConfig() {
+		DefaultClientConfigImpl config = new DefaultClientConfigImpl();
+		config.setClientName("testapp");
+		config.setProperty(KubernetesConfigKey.Namespace,"testns");
+		config.setProperty(CommonClientConfigKey.ServerListRefreshInterval,"500");
+		return config;
+	}
+
+}

--- a/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/TestApplication.java
+++ b/spring-cloud-kubernetes-ribbon/src/test/java/org/springframework/cloud/kubernetes/ribbon/TestApplication.java
@@ -1,10 +1,8 @@
 package org.springframework.cloud.kubernetes.ribbon;
 
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.DefaultClientConfigImpl;
-import com.netflix.client.config.IClientConfig;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
@@ -12,7 +10,8 @@ import org.springframework.web.client.RestTemplate;
 /**
  * @author <a href="mailto:cmoullia@redhat.com">Charles Moulliard</a>
  */
-@SpringBootApplication
+@EnableAutoConfiguration
+@SpringBootConfiguration
 public class TestApplication {
 
 	public static void main(String[] args) {
@@ -23,17 +22,6 @@ public class TestApplication {
 	@Bean
 	public RestTemplate restTemplate() {
 		return new RestTemplate();
-	}
-
-
-	// TODO - Should be refactored when we will fix how the Default client could be created out of the box
-	@Bean
-	public IClientConfig ribbonClientConfig() {
-		DefaultClientConfigImpl config = new DefaultClientConfigImpl();
-		config.setClientName("testapp");
-		config.setProperty(KubernetesConfigKey.Namespace,"testns");
-		config.setProperty(CommonClientConfigKey.ServerListRefreshInterval,"500");
-		return config;
 	}
 
 }

--- a/spring-cloud-kubernetes-ribbon/src/test/resources/application.yml
+++ b/spring-cloud-kubernetes-ribbon/src/test/resources/application.yml
@@ -2,3 +2,4 @@ testapp:
   ribbon:
     eureka:
       enabled: false
+    ServerListRefreshInterval: 500

--- a/spring-cloud-kubernetes-ribbon/src/test/resources/logback-test.xml
+++ b/spring-cloud-kubernetes-ribbon/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/base.xml" />
+	<logger name="org.hibernate.validator" level="info" /> <!-- Validator prints a lot of debug messages during integration tests -->
+	<logger name="okhttp3.mockwebserver" level="debug" />
+</configuration>


### PR DESCRIPTION
Add java test case covering Ribbon where 3 scenario are played. 

1) Register a kubernetes endpoint and call using Ribbon Client discovery the mock endpoint
2) Unregister kubernetes endpoint and can't call the mock endpoint as the ribbon list is empty
3) Re register again the kubernetes endpoint and call using Ribbon Client discovery the mock endpoint

REMARK : The test will fail as it requires #82 