### PR TITLE
Update spring-cloud-* versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
 
 	<properties>
 		<!-- Dependency Versions -->
-		<spring-cloud-commons.version>1.1.7.BUILD-SNAPSHOT</spring-cloud-commons.version>
-		<spring-cloud-netflix.version>1.2.4.BUILD-SNAPSHOT</spring-cloud-netflix.version>
-		<spring-cloud-sleuth.version>1.1.1.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
+		<spring-cloud-commons.version>1.2.0.RELEASE</spring-cloud-commons.version>
+		<spring-cloud-netflix.version>1.3.0.RELEASE</spring-cloud-netflix.version>
+		<spring-cloud-sleuth.version>1.2.0.RELEASE</spring-cloud-sleuth.version>
 
 		<!-- Maven Plugin Versions -->
 		<maven-compiler-plugin.version>3.5</maven-compiler-plugin.version>


### PR DESCRIPTION
Update spring-cloud-netflix, spring-cloud-sleuth & commons to use RELEASE versions instead of SNAPSHOT. Fix #82