### PR TITLE
Update pom file to use 1.3.3.BUILD-SNAPSHOT of spring-cloud-build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.2.2.BUILD-SNAPSHOT</version>
+		<version>1.3.3.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-kubernetes-config/src/test/groovy/org/springframework/cloud/kubernetes/config/CoreTest.groovy
+++ b/spring-cloud-kubernetes-config/src/test/groovy/org/springframework/cloud/kubernetes/config/CoreTest.groovy
@@ -24,20 +24,20 @@ import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.server.mock.KubernetesMockServer
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
-import org.springframework.boot.test.IntegrationTest
-import org.springframework.boot.test.SpringApplicationConfiguration
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.core.env.Environment
+import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 import groovy.util.logging.Slf4j
 
 @Slf4j
-@SpringApplicationConfiguration(TestApplication.class)
-@IntegrationTest([
-    "spring.application.name=testapp",
-    "spring.cloud.kubernetes.client.namespace=testns",
-    "spring.cloud.kubernetes.client.trustCerts=true",
-    "spring.cloud.kubernetes.config.namespace=testns",
-    "spring.cloud.kubernetes.secrets.enableApi=true"
+@ContextConfiguration(classes=[TestApplication.class])
+@SpringBootTest(properties=[
+	"spring.application.name=testapp",
+	"spring.cloud.kubernetes.client.namespace=testns",
+	"spring.cloud.kubernetes.client.trustCerts=true",
+	"spring.cloud.kubernetes.config.namespace=testns",
+	"spring.cloud.kubernetes.secrets.enableApi=true"
 ])
 @EnableConfigurationProperties
 class CoreTest extends Specification {

--- a/spring-cloud-kubernetes-dependencies/pom.xml
+++ b/spring-cloud-kubernetes-dependencies/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.2.2.BUILD-SNAPSHOT</version>
+		<version>1.3.3.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-kubernetes-dependencies</artifactId>

--- a/spring-cloud-kubernetes-ribbon/src/test/groovy/io/fabric8/spring/cloud/kubernetes/ribbon/test/RibbonTest.groovy
+++ b/spring-cloud-kubernetes-ribbon/src/test/groovy/io/fabric8/spring/cloud/kubernetes/ribbon/test/RibbonTest.groovy
@@ -21,19 +21,19 @@ import io.fabric8.kubernetes.api.model.EndpointsBuilder
 import io.fabric8.kubernetes.client.Config
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.server.mock.KubernetesMockServer
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cloud.kubernetes.ribbon.KubernetesRibbonClientConfiguration
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.test.IntegrationTest
-import org.springframework.boot.test.SpringApplicationConfiguration
 import org.springframework.cloud.client.loadbalancer.LoadBalancerInterceptor
 import org.springframework.cloud.netflix.ribbon.RibbonClient
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
 
 @EnableAutoConfiguration
-@SpringApplicationConfiguration(TestApplication.class)
-@IntegrationTest(
+@ContextConfiguration(classes=[TestApplication.class])
+@SpringBootTest(properties=
         [
                 "spring.application.name=testapp",
                 "spring.cloud.kubernetes.client.namespace=testns",


### PR DESCRIPTION
Update pom file to use 1.3.3.BUILD-SNAPSHOT of spring-cloud-build

- Pom file changed : spring-cloud-kubernetes-dependencies
- Pom file changed : spring-cloud-kubernetes

No SNASPHOT versions are now reported under sck-core

```
INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ spring-cloud-kubernetes-core ---
[INFO] org.springframework.cloud:spring-cloud-kubernetes-core:jar:0.2.0.BUILD-SNAPSHOT
[INFO] +- io.fabric8:kubernetes-client:jar:2.2.0:compile
[INFO] |  +- io.fabric8:kubernetes-model:jar:1.0.67:compile
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.7.5:compile
[INFO] |  |  \- javax.validation:validation-api:jar:1.1.0.Final:compile
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:3.6.0:compile
[INFO] |  |  \- com.squareup.okio:okio:jar:1.11.0:compile
[INFO] |  +- com.squareup.okhttp3:logging-interceptor:jar:3.6.0:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] |  +- org.slf4j:jul-to-slf4j:jar:1.7.25:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.7.7:compile
[INFO] |  |  \- org.yaml:snakeyaml:jar:1.17:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.7.7:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.7.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.7.7:compile
[INFO] |  +- io.fabric8:zjsonpatch:jar:0.3.0:compile
[INFO] |  \- com.github.mifmif:generex:jar:1.0.1:compile
[INFO] |     \- dk.brics.automaton:automaton:jar:1.11-8:compile
[INFO] +- org.springframework.boot:spring-boot-starter-logging:jar:1.5.3.RELEASE:compile
[INFO] |  +- ch.qos.logback:logback-classic:jar:1.1.11:compile
[INFO] |  |  \- ch.qos.logback:logback-core:jar:1.1.11:compile
[INFO] |  +- org.slf4j:jcl-over-slf4j:jar:1.7.25:compile
[INFO] |  \- org.slf4j:log4j-over-slf4j:jar:1.7.25:compile
[INFO] +- org.springframework.boot:spring-boot-actuator:jar:1.5.3.RELEASE:compile
[INFO] |  +- org.springframework.boot:spring-boot:jar:1.5.3.RELEASE:compile
[INFO] |  +- org.springframework:spring-core:jar:4.3.8.RELEASE:compile
[INFO] |  \- org.springframework:spring-context:jar:4.3.8.RELEASE:compile
[INFO] |     +- org.springframework:spring-aop:jar:4.3.8.RELEASE:compile
[INFO] |     +- org.springframework:spring-beans:jar:4.3.8.RELEASE:compile
[INFO] |     \- org.springframework:spring-expression:jar:4.3.8.RELEASE:compile
[INFO] +- org.springframework.boot:spring-boot-autoconfigure:jar:1.5.3.RELEASE:compile
[INFO] +- org.springframework.cloud:spring-cloud-context:jar:1.2.0.RELEASE:compile
[INFO] |  \- org.springframework.security:spring-security-crypto:jar:4.2.2.RELEASE:compile
[INFO] +- org.projectlombok:lombok:jar:1.16.14:provided
[INFO] +- org.springframework.boot:spring-boot-starter-test:jar:1.5.3.RELEASE:test
[INFO] |  +- org.springframework.boot:spring-boot-test:jar:1.5.3.RELEASE:test
[INFO] |  +- org.springframework.boot:spring-boot-test-autoconfigure:jar:1.5.3.RELEASE:test
[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.2.0:test
[INFO] |  |  \- net.minidev:json-smart:jar:2.2.1:test
[INFO] |  |     \- net.minidev:accessors-smart:jar:1.1:test
[INFO] |  |        \- org.ow2.asm:asm:jar:5.0.3:test
[INFO] |  +- junit:junit:jar:4.12:test
[INFO] |  +- org.assertj:assertj-core:jar:2.6.0:test
[INFO] |  +- org.mockito:mockito-core:jar:1.10.19:test
[INFO] |  |  \- org.objenesis:objenesis:jar:2.1:test
[INFO] |  +- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] |  +- org.hamcrest:hamcrest-library:jar:1.3:test
[INFO] |  +- org.skyscreamer:jsonassert:jar:1.4.0:test
[INFO] |  \- org.springframework:spring-test:jar:4.3.8.RELEASE:test
[INFO] +- org.springframework.boot:spring-boot-starter-web:jar:1.5.3.RELEASE:test
[INFO] |  +- org.springframework.boot:spring-boot-starter:jar:1.5.3.RELEASE:test
[INFO] |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:1.5.3.RELEASE:test
[INFO] |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:8.5.14:test
[INFO] |  |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:8.5.14:test
[INFO] |  |  \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:8.5.14:test
[INFO] |  +- org.hibernate:hibernate-validator:jar:5.3.5.Final:test
[INFO] |  |  +- org.jboss.logging:jboss-logging:jar:3.3.1.Final:test
[INFO] |  |  \- com.fasterxml:classmate:jar:1.3.3:test
[INFO] |  +- org.springframework:spring-web:jar:4.3.8.RELEASE:test
[INFO] |  \- org.springframework:spring-webmvc:jar:4.3.8.RELEASE:test
[INFO] +- io.fabric8:kubernetes-client:test-jar:tests:2.2.0:test
[INFO] +- io.fabric8:mockwebserver:jar:0.0.12:test
[INFO] |  +- com.squareup.okhttp3:mockwebserver:jar:3.6.0:test
[INFO] |  |  \- org.bouncycastle:bcprov-jdk15on:jar:1.50:test
[INFO] |  \- io.sundr:builder-annotations:jar:0.2.7:test
[INFO] |     +- io.sundr:sundr-core:jar:0.2.7:test
[INFO] |     +- io.sundr:sundr-codegen:jar:0.2.7:test
[INFO] |     |  \- org.apache.velocity:velocity:jar:1.7:test
[INFO] |     |     +- commons-collections:commons-collections:jar:3.2.2:test
[INFO] |     |     \- commons-lang:commons-lang:jar:2.4:test
[INFO] |     \- com.sun:tools:jar:1.7:system
[INFO] +- org.spockframework:spock-spring:jar:1.0-groovy-2.3:test
[INFO] |  +- org.codehaus.groovy:groovy-all:jar:2.4.10:test
[INFO] |  \- org.spockframework:spock-core:jar:1.0-groovy-2.4:test
[INFO] \- org.springframework.boot:spring-boot-configuration-processor:jar:1.5.3.RELEASE:compile
[INFO]    \- com.vaadin.external.google:android-json:jar:0.0.20131108.vaadin1:compile
```