### PR TITLE
Typo fixes in README.md and fixed wrong logger context in KubernetesAutoConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This is something that you get for free just by adding the following dependency 
 <dependency>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-starter-kubernetes</artifactId>
-    <version>${latest.version></version>
+    <version>${latest.version}</version>
 </dependency>
 ```
 
@@ -434,7 +434,7 @@ The implementation is part of the following starter that you can use by adding i
 <dependency>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-starter-kubernetes-netflix</artifactId>
-    <version>${latest.version></version>
+    <version>${latest.version}</version>
 </dependency>
 ```
 
@@ -450,7 +450,7 @@ dedicated `ConfigMap`) using the following format: `<name of your service>.ribbo
 
 - `<name of your service>` corresponds to the service name you're accessing over Ribbon, as configured using the 
 `@RibbonClient` annotation (e.g. `name-service` in the example above)
-- `<Ribbon configuration key` is one of the Ribbon configuration key defined by 
+- `<Ribbon configuration key>` is one of the Ribbon configuration key defined by
 [Ribbon's CommonClientConfigKey class](https://github.com/Netflix/ribbon/blob/master/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java)
 
 Additionally, the `spring-cloud-kubernetes-ribbon` project defines two additional configuration keys to further 
@@ -488,7 +488,7 @@ can use by adding this starter to your maven pom file:
 <dependency>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-starter-kubernetes-zipkin</artifactId>
-    <version>${latest.version></version>
+    <version>${latest.version}</version>
 </dependency>
 ```
 

--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesAutoConfiguration.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesAutoConfiguration.java
@@ -36,7 +36,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 @EnableConfigurationProperties(KubernetesClientProperties.class)
 public class KubernetesAutoConfiguration {
 
-    private static final Log LOG = LogFactory.getLog(KubernetesClientProperties.class);
+    private static final Log LOG = LogFactory.getLog(KubernetesAutoConfiguration.class);
 
     @Bean
     @ConditionalOnMissingBean(Config.class)


### PR DESCRIPTION
fixed typo in maven deps and added missing > in README.