### PR TITLE
Allow ConfigMaps to be parsed from mounted volume paths, like Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ spec:
 | spring.cloud.kubernetes.config.enabled   | Boolean | true                       | Enable Secrets PropertySource
 | spring.cloud.kubernetes.config.name      | String  | ${spring.application.name} | Sets the name of ConfigMap to lookup
 | spring.cloud.kubernetes.config.namespace | String  | Client namespace           | Sets the Kubernetes namespace where to lookup
-    
+| spring.cloud.kubernetes.config.paths     | List    | null                       | Sets the paths were ConfigMaps are mounted
+| spring.cloud.kubernetes.config.enableApi | Boolean | true                       | Enable/Disable consuming ConfigMaps via APIs
+
 
 #### Secrets PropertySource
 

--- a/spring-cloud-kubernetes-config/pom.xml
+++ b/spring-cloud-kubernetes-config/pom.xml
@@ -86,12 +86,6 @@
 			<artifactId>rest-assured</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
-			<scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-kubernetes-config/pom.xml
+++ b/spring-cloud-kubernetes-config/pom.xml
@@ -72,6 +72,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-server-mock</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.spockframework</groupId>
 			<artifactId>spock-spring</artifactId>
 			<scope>test</scope>
@@ -79,6 +84,12 @@
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.6</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
@@ -17,6 +17,9 @@
 
 package org.springframework.cloud.kubernetes.config;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("spring.cloud.kubernetes.config")
@@ -24,7 +27,26 @@ public class ConfigMapConfigProperties extends AbstractConfigProperties {
 
     private static final String TARGET = "Config Map";
 
-    @Override
+	private boolean enableApi = true;
+	private List<String> paths = new LinkedList<>();
+
+	public boolean isEnableApi() {
+		return enableApi;
+	}
+
+	public void setEnableApi(boolean enableApi) {
+		this.enableApi = enableApi;
+	}
+
+	public void setPaths(List<String> paths) {
+		this.paths = paths;
+	}
+
+	public List<String> getPaths() {
+		return paths;
+	}
+
+	@Override
     public String getConfigurationTarget() {
         return TARGET;
     }

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
@@ -41,7 +41,7 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
             ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
             String name = getApplicationName(environment, properties);
             String namespace = getApplicationNamespace(client, env, properties);
-            return new ConfigMapPropertySource(client, name, namespace, env.getActiveProfiles());
+            return new ConfigMapPropertySource(client, name, namespace, env.getActiveProfiles(), properties);
         }
         return null;
     }

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/KubernetesPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/KubernetesPropertySource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017 to the original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.kubernetes.config;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.env.MapPropertySource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Secrets and ConfigMaps shared features.
+ */
+public class KubernetesPropertySource extends MapPropertySource {
+	private static final Log LOG = LogFactory.getLog(KubernetesPropertySource.class);
+
+	@SuppressWarnings("unchecked")
+	protected KubernetesPropertySource(String name, Map<String, Object> source) {
+		super(name, source);
+	}
+
+	protected static void putPathConfig(Map<String, ? super String> result, List<String> paths) {
+		paths
+			.stream()
+			.map(Paths::get)
+			.filter(Files::exists)
+			.forEach(p -> putAll(p, result));
+	}
+
+	private static void putAll(Path path, Map<String, ? super String> result) {
+		try {
+			Files.walk(path)
+				.filter(Files::isRegularFile)
+				.forEach(p -> readFile(p, result));
+		} catch (IOException e) {
+			LOG.warn("Error walking properties files", e);
+		}
+	}
+
+	private static void readFile(Path path, Map<String, ? super String> result) {
+		try {
+			result.put(
+				path.getFileName().toString(),
+				new String(Files.readAllBytes(path)).trim());
+		} catch (IOException e) {
+			LOG.warn("Error reading properties file", e);
+		}
+	}
+}

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsSpringBootTest.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.server.mock.KubernetesServer;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.restassured.RestAssured;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -53,18 +53,18 @@ public class ConfigMapsSpringBootTest {
 	@ClassRule
 	public static KubernetesServer server = new KubernetesServer();
 
-	public static KubernetesClient mockClient;
+	private static KubernetesClient mockClient;
 
 	@Autowired(required = false)
 	Config config;
 
-	private static String APPLICATION_NAME = "configmap-example";
+	private static final String APPLICATION_NAME = "configmap-example";
 
 	@Value("${local.server.port}")
 	private int port;
 
 	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+	public static void setUpBeforeClass() {
 		mockClient = server.getClient();
 
 		//Configure the kubernetes master url to point to the mock server

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
@@ -29,9 +29,9 @@ import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.ConfigMapListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
+import org.springframework.util.FileSystemUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -98,7 +98,7 @@ public class ConfigMapsTest {
 		assertEquals("http://localhost/api", cmps.getProperty("api.url"));
 		assertFalse(cmps.containsProperty("no.such.property"));
 
-		FileUtils.deleteDirectory(tmp.toFile());
+		FileSystemUtils.deleteRecursively(tmp.toFile());
 	}
 
 	private void createConfigMapFile(Path basePath, String key, String value) throws IOException {


### PR DESCRIPTION
Allows making ConfigMaps available as spring properties from Kubernetes volumes, just like is currently possible with Secrets. This allows using ConfigMaps without resorting to environment variables or enabling extra permissions for service accounts. Seems this would offer a workaround/solution for #141, probably #138, #137 and #129.

See also the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#add-configmap-data-to-a-volume) on how to configure this on the Kubernetes side.