### PR TITLE
Remove duplicate logic from addKubernetesProfile

### DIFF
--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileApplicationListener.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileApplicationListener.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.kubernetes.profile;
 
-import io.fabric8.kubernetes.api.model.Pod;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.kubernetes.PodUtils;
@@ -47,13 +45,6 @@ public class KubernetesProfileApplicationListener implements ApplicationListener
     }
 
     void addKubernetesProfile(ConfigurableEnvironment environment) {
-        Pod current = utils.currentPod().get();
-        if (current != null) {
-            if (!hasKubernetesProfile(environment)) {
-                environment.addActiveProfile(KUBERNETES_PROFILE);
-            }
-        }
-
         if (utils.isInsideKubernetes()) {
             if (hasKubernetesProfile(environment)) {
                 if (LOG.isDebugEnabled()) {

--- a/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileApplicationListenerTest.java
+++ b/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileApplicationListenerTest.java
@@ -1,0 +1,53 @@
+package org.springframework.cloud.kubernetes.profile;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.cloud.kubernetes.PodUtils;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesProfileApplicationListenerTest {
+
+	private static final String[] ACTIVE_PROFILES = new String[0];
+
+	@Mock
+	private ConfigurableEnvironment mockEnvironment;
+
+	@Mock
+	private PodUtils mockPodUtils;
+
+	@Mock
+	private ApplicationEnvironmentPreparedEvent mockEvent;
+
+	private KubernetesProfileApplicationListener listener;
+
+	@Before
+	public void before() {
+		when(mockEnvironment.getActiveProfiles()).thenReturn(ACTIVE_PROFILES);
+		when(mockEvent.getEnvironment()).thenReturn(mockEnvironment);
+		listener = new KubernetesProfileApplicationListener(mockPodUtils);
+	}
+
+	@Test
+	public void shouldEnableKubernetesProfile() {
+		when(mockPodUtils.isInsideKubernetes()).thenReturn(true);
+		listener.onApplicationEvent(mockEvent);
+		verify(mockEnvironment).addActiveProfile("kubernetes");
+	}
+
+	@Test
+	public void shouldNotEnableKubernetesProfile() {
+		when(mockPodUtils.isInsideKubernetes()).thenReturn(false);
+		listener.onApplicationEvent(mockEvent);
+		verify(mockEnvironment, times(0)).addActiveProfile("kubernetes");
+	}
+
+}


### PR DESCRIPTION
First part of the `addKubernetesProfile` method executes the same logic as the second part, just without logging.