### PR TITLE
Add important documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This is something that you get for free just by adding the following dependency 
 </dependency>
 ```
 
+To enable loading of the `DiscoveryClient`, add `@EnableDiscoveryClient` to the according configuration or application class.
+
 Then you can inject the client in your code simply by:
 
 ```java


### PR DESCRIPTION
It took me a while to find out why the discoveryClient did only return empty attributes (e.g. serviceList) .

Adding `@EnableDiscoveryClient` fixed this for me.