### PR TITLE
added support for ConfigMap built from files

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
@@ -76,28 +76,40 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 					: client.configMaps().inNamespace(namespace).withName(name).get();
 
 				if (map != null) {
-					for (Map.Entry<String, String> entry : map.getData().entrySet()) {
-						String key = entry.getKey();
-						String value = entry.getValue();
-						if (key.equals(APPLICATION_YAML) || key.equals(APPLICATION_YML)) {
-							result.putAll(yamlParserGenerator(profiles).andThen(PROPERTIES_TO_MAP).apply(value));
-						} else if (key.equals(APPLICATION_PROPERTIES)) {
-							result.putAll(KEY_VALUE_TO_PROPERTIES.andThen(PROPERTIES_TO_MAP).apply(value));
-						} else {
-							result.put(key, value);
-						}
-					}
+					result.putAll(processAllEntries(map.getData(), profiles));
 				}
 			} catch (Exception e) {
 				LOG.warn("Can't read configMap with name: [" + name + "] in namespace:[" + namespace + "]. Ignoring", e);
 			}
 		}
 
-		// read for secrets mount
-		putPathConfig(result, config.getPaths());
-
+		Map<String, String> configsFromPaths = new HashMap<>();
+		putPathConfig(configsFromPaths, config.getPaths());
+		result.putAll(processAllEntries(configsFromPaths, profiles));
 		return result;
     }
+
+	private static Map<String, String> processAllEntries(Map<String, String> input,
+		String[] profiles) {
+		return input.entrySet().stream()
+				.map(e -> extractProperties(e.getKey(), e.getValue(), profiles))
+				.filter(m -> !m.isEmpty())
+				.flatMap(m -> m.entrySet().stream())
+				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+	}
+
+	private static Map<String, String> extractProperties(String resourceName, String content, String[] profiles) {
+		Map<String, String> result = new HashMap<>();
+
+    	if (resourceName.equals(APPLICATION_YAML) || resourceName.equals(APPLICATION_YML)) {
+			result.putAll(yamlParserGenerator(profiles).andThen(PROPERTIES_TO_MAP).apply(content));
+		} else if (resourceName.equals(APPLICATION_PROPERTIES)) {
+			result.putAll(KEY_VALUE_TO_PROPERTIES.andThen(PROPERTIES_TO_MAP).apply(content));
+		} else {
+			result.put(resourceName, content);
+		}
+			return result;
+		}
 
     private static Map<String, Object> asObjectMap(Map<String, String> source) {
         return source.entrySet()

--- a/spring-cloud-kubernetes-config/src/test/resources/application.properties
+++ b/spring-cloud-kubernetes-config/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+dummy.property.string1=a
+dummy.property.int1=1
+dummy.property.bool1=true

--- a/spring-cloud-kubernetes-config/src/test/resources/application.yaml
+++ b/spring-cloud-kubernetes-config/src/test/resources/application.yaml
@@ -1,0 +1,5 @@
+dummy:
+  property:
+    string2: "a"
+    int2: 1
+    bool2: true


### PR DESCRIPTION
I have added support handling **ConfigMaps** specified via `spring.cloud.kubernetes.config.paths` that are build from `application.properties` or `application.yml `files.
Previously any content inside the paths were handled just like **Secrets** - the file would be a property name and the content of the file, it's value.
Now we check for the file name and in case it is an application config file it's parsed and the configs inside them are added instead.
This is the same functionality that was used when specifying **named** configs, it was just reused for configs specified via **paths**.