### PR TITLE
Populate ServiceInstance Metadata from Service Labels

### DIFF
--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstance.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstance.java
@@ -38,12 +38,14 @@ public class KubernetesServiceInstance implements ServiceInstance {
     private final EndpointAddress endpointAddress;
     private final EndpointPort endpointPort;
     private final Boolean secure;
+	private final Map<String,String> metadata;
 
-    public KubernetesServiceInstance(String serviceId, EndpointAddress endpointAddress, EndpointPort endpointPort, Boolean secure) {
+    public KubernetesServiceInstance(String serviceId, EndpointAddress endpointAddress, EndpointPort endpointPort, Boolean secure, Map<String, String> metadata) {
         this.serviceId = serviceId;
         this.endpointAddress = endpointAddress;
         this.endpointPort = endpointPort;
         this.secure = secure;
+        this.metadata = metadata;
     }
 
     @Override
@@ -85,6 +87,6 @@ public class KubernetesServiceInstance implements ServiceInstance {
     }
 
     public Map<String, String> getMetadata() {
-        return Collections.EMPTY_MAP;
+        return metadata;
     }
 }

--- a/spring-cloud-kubernetes-zipkin/src/main/java/org/springframework/cloud/kubernetes/zipkin/ZipkinKubernetesAutoConfiguration.java
+++ b/spring-cloud-kubernetes-zipkin/src/main/java/org/springframework/cloud/kubernetes/zipkin/ZipkinKubernetesAutoConfiguration.java
@@ -18,6 +18,8 @@
 package org.springframework.cloud.kubernetes.zipkin;
 
 import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.Utils;
 import org.springframework.cloud.kubernetes.discovery.KubernetesServiceInstance;
@@ -37,7 +39,9 @@ import org.springframework.util.Assert;
 import org.springframework.web.client.RestTemplate;
 import zipkin.Span;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -71,11 +75,28 @@ public class ZipkinKubernetesAutoConfiguration {
                 .orElse(new Endpoints())
                 .getSubsets()
                 .stream()
-                .flatMap(s -> s.getAddresses().stream().map(a -> (ServiceInstance) new KubernetesServiceInstance(name, a ,s.getPorts().stream().findFirst().orElseThrow(IllegalStateException::new), false)))
+                .flatMap(s -> s.getAddresses().stream().map(a -> (ServiceInstance) new KubernetesServiceInstance(name, a ,s.getPorts().stream().findFirst().orElseThrow(IllegalStateException::new), false, getServiceLabels(client,name))))
                 .collect(Collectors.toList());
     }
 
-    static final class NullZipkinSpanReporter implements ZipkinSpanReporter {
+
+	private static Map<String,String> getServiceLabels(KubernetesClient client, String serviceId) {
+
+		Map<String, String> labels = null;
+
+		Service service = client.services().withName(serviceId).get();
+		if (service != null) {
+			ObjectMeta metadata = service.getMetadata();
+			if(metadata != null)
+				labels = metadata.getLabels();
+		}
+		if(labels == null)
+			labels = Collections.EMPTY_MAP;
+		return labels;
+	}
+
+
+	static final class NullZipkinSpanReporter implements ZipkinSpanReporter {
 
         @Override
         public void report(Span span) {


### PR DESCRIPTION
I wanted to run `spring-boot-admin` on kubernetes and found that for services with the context-map set to anything other than /  it will not work.  

I needed to populate some data in `Metadata` in `org.springframework.cloud.client.ServiceInstance` and found that currently it is set to `EmptyMap` so I thought we can customize this by getting them from service labels for example
```
apiVersion: v1
kind: Service
metadata:
  labels:
    app: ui
    management.context-path: ui
  name: ui
  namespace: default
spec:
  clusterIP: 10.103.4.107
  ports:
  - port: 8085
    protocol: TCP
    targetPort: 8085
  selector:
    app: ui
  sessionAffinity: None
  type: ClusterIP
```
In the above example it is read from `management.context-path`