### PR TITLE
Support Global or Common application config map

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ The [Spring Cloud Kubernetes Config](./spring-cloud-kubernetes-config) project m
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on 
 observed `ConfigMap`s.
 
-`ConfigMapPropertySource` will search for a Kubernetes `ConfigMap` which `metadata.name` is either the name of 
-your Spring application (as defined by its `spring.application.name` property) or a custom name defined within the
+`ConfigMapPropertySource` will search for a Kubernetes `ConfigMap` as below
+- `global` is a global common config map (This can be used to hold global configuration for all pods)
+- `metadata.name` is either the name of your Spring application (as defined by its `spring.application.name` property) or a custom name defined within the
 `bootstrap.properties` file under the following key `spring.cloud.kubernetes.config.name`.
+- `metadata.name-profile` same name 2nd step but with active profiles added
 
 If such a `ConfigMap` is found, it will be processed as follows:
 

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsSpringBootTest.java
@@ -39,16 +39,18 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author <a href="mailto:cmoullia@redhat.com">Charles Moulliard</a>
+ * @author <a href="mailto:shahbour@gmail.com">Ali Shahbour</a>
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
                 classes = App.class,
 				properties = { "spring.application.name=configmap-example",
-	           "spring.cloud.kubernetes.reload.enabled=false"}
-	           )
+	           "spring.cloud.kubernetes.reload.enabled=false",
+				"spring.profiles.active=production"})
 public class ConfigMapsSpringBootTest {
 
 	@ClassRule
@@ -59,7 +61,9 @@ public class ConfigMapsSpringBootTest {
 	@Autowired(required = false)
 	Config config;
 
+	private static final String GLOBAL_APPLICATION = "global";
 	private static final String APPLICATION_NAME = "configmap-example";
+	private static final String ACTIVE_PROFILE = "production";
 
 	@Value("${local.server.port}")
 	private int port;
@@ -75,19 +79,38 @@ public class ConfigMapsSpringBootTest {
 		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
 		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
 
+		HashMap<String,String> global = new HashMap<>();
+		global.put("bean.global","Hello ConfigMap Global, %s!");
+		global.put("bean.message","Hello ConfigMap Global, %s!");  // This should be ignored by application name properties
+		server.expect().withPath("/api/v1/namespaces/test/configmaps/" + GLOBAL_APPLICATION).andReturn(200, new ConfigMapBuilder()
+			.withNewMetadata().withName(GLOBAL_APPLICATION).endMetadata()
+			.addToData(global)
+			.build())
+			.always();
+
 		HashMap<String,String> data = new HashMap<>();
 		data.put("bean.message","Hello ConfigMap, %s!");
+		data.put("bean.profile","Hello ConfigMap, %s!");  // This should be ignored by profiles properties
 		server.expect().withPath("/api/v1/namespaces/test/configmaps/" + APPLICATION_NAME).andReturn(200, new ConfigMapBuilder()
 			.withNewMetadata().withName(APPLICATION_NAME).endMetadata()
 			.addToData(data)
 			.build())
 			.always();
+
+		HashMap<String,String> profile = new HashMap<>();
+		profile.put("bean.profile","Hello ConfigMap Profile, %s!");
+		server.expect().withPath("/api/v1/namespaces/test/configmaps/" + APPLICATION_NAME + "-" + ACTIVE_PROFILE).andReturn(200, new ConfigMapBuilder()
+			.withNewMetadata().withName(APPLICATION_NAME + "-" + ACTIVE_PROFILE).endMetadata()
+			.addToData(profile)
+			.build())
+			.always();
+
 	}
 
 
 	@Before
 	public void setUp() {
-		RestAssured.baseURI = String.format("http://localhost:%d/api/greeting", port);
+		RestAssured.baseURI = String.format("http://localhost:%d/api/", port);
 	}
 
 	@Test
@@ -96,19 +119,56 @@ public class ConfigMapsSpringBootTest {
 		assertEquals(config.getNamespace(),mockClient.getNamespace());
 	}
 
+
+	@Test
+	public void testGlobalEndpoint() {
+		when().get("global")
+			.then()
+			.statusCode(200)
+			.body("content", is("Hello ConfigMap Global, World!"));
+	}
+
 	@Test
 	public void testGreetingEndpoint() {
-		when().get()
+		when().get("greeting")
 			.then()
 			.statusCode(200)
 			.body("content", is("Hello ConfigMap, World!"));
 	}
 
 	@Test
+	public void testProfileEndpoint() {
+		when().get("profile")
+			.then()
+			.statusCode(200)
+			.body("content", is("Hello ConfigMap Profile, World!"));
+	}
+
+	@Test
+	public void testGlobalConfigMap() {
+		ConfigMap configmap = mockClient.configMaps().inNamespace("test").withName(GLOBAL_APPLICATION).get();
+		HashMap<String,String> keys = (HashMap<String, String>) configmap.getData();
+		assertEquals(keys.get("bean.global"),"Hello ConfigMap Global, %s!");
+		assertEquals(keys.get("bean.message"),"Hello ConfigMap Global, %s!");
+		assertNull(keys.get("bean.profile"));
+	}
+
+	@Test
 	public void testConfigMap() {
 		ConfigMap configmap = mockClient.configMaps().inNamespace("test").withName(APPLICATION_NAME).get();
 		HashMap<String,String> keys = (HashMap<String, String>) configmap.getData();
+		assertNull(keys.get("bean.global"));
 		assertEquals(keys.get("bean.message"),"Hello ConfigMap, %s!");
+		assertEquals(keys.get("bean.profile"),"Hello ConfigMap, %s!");
+	}
+
+	@Test
+	public void testProfileConfigMap() {
+		ConfigMap configmap = mockClient.configMaps().inNamespace("test").withName(APPLICATION_NAME + "-" + ACTIVE_PROFILE).get();
+		HashMap<String,String> keys = (HashMap<String, String>) configmap.getData();
+		assertNull(keys.get("bean.global"));
+		assertNull(keys.get("bean.message"));
+		assertEquals(keys.get("bean.profile"),"Hello ConfigMap Profile, %s!");
 	}
 
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingController.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * @author <a href="mailto:cmoullia@redhat.com">Charles Moulliard</a>
+ * @author <a href="mailto:shahbour@gmail.com">Ali Shahbour</a>
  */
 @RestController
 public class GreetingController {
@@ -38,6 +39,18 @@ public class GreetingController {
 	@RequestMapping("/api/greeting")
 	public Greeting greeting(@RequestParam(value="name", defaultValue="World") String name) {
 		String message = String.format(properties.getMessage(), name);
+		return new Greeting(message);
+	}
+
+	@RequestMapping("/api/global")
+	public Greeting global(@RequestParam(value="name", defaultValue="World") String name) {
+		String message = String.format(properties.getGlobal(), name);
+		return new Greeting(message);
+	}
+
+	@RequestMapping("/api/profile")
+	public Greeting profile(@RequestParam(value="name", defaultValue="World") String name) {
+		String message = String.format(properties.getProfile(), name);
 		return new Greeting(message);
 	}
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingProperties.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingProperties.java
@@ -25,6 +25,8 @@ import org.springframework.context.annotation.Configuration;
 public class GreetingProperties {
 
 	private String message = "Hello, %s!";
+	private String global = "Hello, %s!";
+	private String profile = "Hello, %s!";
 
 	public String getMessage() {
 		return message;
@@ -34,4 +36,11 @@ public class GreetingProperties {
 		this.message = message;
 	}
 
+	public String getGlobal() { return global; }
+
+	public void setGlobal(String global) { this.global = global; }
+
+	public String getProfile() { return profile; }
+
+	public void setProfile(String profile) { this.profile = profile; }
 }


### PR DESCRIPTION
Support Global config map called application
Support Specific config map per active profile
So a service with name sample and active profiles production , mysql will try to get the following config maps

application
sample
sample-production
sample-mysql

This is related to [issue](https://github.com/spring-cloud-incubator/spring-cloud-kubernetes/issues/153) create by me