### PR TITLE
Change package of MockitoJUnitRunner

### DIFF
--- a/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/LazilyInstantiateTest.java
+++ b/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/LazilyInstantiateTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LazilyInstantiateTest {

--- a/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileApplicationListenerTest.java
+++ b/spring-cloud-kubernetes-core/src/test/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileApplicationListenerTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.cloud.kubernetes.PodUtils;
 import org.springframework.core.env.ConfigurableEnvironment;

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.context.ApplicationEventPublisher;
 


### PR DESCRIPTION
The old `org.mockito.runners.MockitoJUnitRunner` has been deprecated in
favor of `org.mockito.junit.MockitoJUnitRunner`