### PR TITLE
Make documentation for DiscoveryClient more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,17 @@ This is something that you get for free just by adding the following dependency 
 </dependency>
 ```
 
-To enable loading of the `DiscoveryClient`, add `@EnableDiscoveryClient` to the according configuration or application class.
+To enable loading of the `DiscoveryClient`, add `@EnableDiscoveryClient` to the according configuration or application class like this:
+
+```java
+@SpringBootApplication
+@EnableDiscoveryClient
+public class Application {  
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}
+```
 
 Then you can inject the client in your code simply by:
 


### PR DESCRIPTION
Close #147 

As @BarDweller pointed out, the documentation is not explicit enough.
This change makes the requirement for the `@EnableDiscoveryClient` annotation more obvious (especially since there is no error message hinting to this problem).