### PR TITLE
Enable/disable failure events publishing during leader election

### DIFF
--- a/spring-cloud-kubernetes-leader/src/main/java/org/springframework/cloud/kubernetes/leader/LeaderProperties.java
+++ b/spring-cloud-kubernetes-leader/src/main/java/org/springframework/cloud/kubernetes/leader/LeaderProperties.java
@@ -91,6 +91,12 @@ public class LeaderProperties {
 	 */
 	private double jitterFactor = DEFAULT_JITTER_FACTOR;
 
+	/**
+	 * Enable/disable publishing events in case leadership acquisition fails.
+	 * Default: false
+	 */
+	private boolean publishFailedEvents = false;
+
 	public boolean isAutoStartup() {
 		return autoStartup;
 	}
@@ -169,5 +175,13 @@ public class LeaderProperties {
 
 	public void setJitterFactor(double jitterFactor) {
 		this.jitterFactor = jitterFactor;
+	}
+
+	public boolean isPublishFailedEvents() {
+		return publishFailedEvents;
+	}
+
+	public void setPublishFailedEvents(boolean publishFailedEvents) {
+		this.publishFailedEvents = publishFailedEvents;
 	}
 }

--- a/spring-cloud-kubernetes-leader/src/main/java/org/springframework/cloud/kubernetes/leader/LeadershipController.java
+++ b/spring-cloud-kubernetes-leader/src/main/java/org/springframework/cloud/kubernetes/leader/LeadershipController.java
@@ -192,8 +192,10 @@ public class LeadershipController {
 	}
 
 	private void handleOnFailed(Candidate candidate) {
-		Context context = new LeaderContext(candidate, this);
-		leaderEventPublisher.publishOnFailedToAcquire(this, context, candidate.getRole());
+		if (leaderProperties.isPublishFailedEvents()) {
+			Context context = new LeaderContext(candidate, this);
+			leaderEventPublisher.publishOnFailedToAcquire(this, context, candidate.getRole());
+		}
 	}
 
 	private Map<String, String> getLeaderData(Candidate candidate) {


### PR DESCRIPTION
Adding a property `spring.cloud.kubernetes.leader.publishFailedEvents` which allows to enable/disable event publishing when leader acquisition fails. It is set to `false` by default because this event is very chatty. Acquisition failure is a normal event while there is a current leader. Other members of the cluster constantly try to take over membership in case if the current leader has disappeared.