### PR TITLE
Rework profile-based app.yaml parsing to support yaml merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ data:
         max:16
 ```
 
-Spring Boot applications can also be configured differently depending on active profiles and it is possible to 
-provide different property values for different profiles using an `application.properties|yaml` property, specifying 
-profile-specific values each in their own document (indicated by the `---` sequence) as follows:
+Spring Boot applications can also be configured differently depending on active profiles which will be merged together
+when the ConfigMap is read. It is possible to provide different property values for different profiles using an
+`application.properties|yaml` property, specifying profile-specific values each in their own document
+(indicated by the `---` sequence) as follows:
  
 ```yaml
 kind: ConfigMap
@@ -147,17 +148,39 @@ data:
   application.yml: |-
     greeting:
       message: Say Hello to the World
+    farewell:
+      message: Say Goodbye
     ---
     spring:
       profiles: development
     greeting:
       message: Say Hello to the Developers
+    farewell:
+      message: Say Goodbye to the Developers
     ---
     spring:
       profiles: production
     greeting:
       message: Say Hello to the Ops
 ```
+
+In the above case, the configuration loaded into your Spring Application with the `development` profile will be:
+```yaml
+  greeting:
+    message: Say Hello to the Developers
+  farewell:
+    message: Say Goodbye to the Developers
+```
+whereas if the `production` profile is active, the configuration will be:
+```yaml
+  greeting:
+    message: Say Hello to the Ops
+  farewell:
+    message: Say Goodbye
+```
+
+If both profiles are active, the property which appears last within the configmap will overwrite preceding values.
+
 
 To tell to Spring Boot which `profile` should be enabled at bootstrap, a system property can be passed to the Java 
 command launching your Spring Boot application using an env variable that you will define with the OpenShift 

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
@@ -18,6 +18,7 @@
 package org.springframework.cloud.kubernetes.config;
 
 import static java.util.Arrays.asList;
+import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.ABSTAIN;
 import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.FOUND;
 import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.NOT_FOUND;
 
@@ -122,13 +123,14 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 	private static Function<String, Properties> yamlParserGenerator(final String[] profiles) {
 		return s -> {
 			YamlPropertiesFactoryBean yamlFactory = new YamlPropertiesFactoryBean();
-			if ((profiles != null) && (profiles.length > 0)){
-				yamlFactory.setDocumentMatchers(
-					(DocumentMatcher) properties ->
-						(asList(profiles).contains(properties.getProperty("spring.profiles")) ?
-							FOUND : NOT_FOUND)
-				);
-			}
+			yamlFactory.setDocumentMatchers(properties -> {
+				String profileProperty = properties.getProperty("spring.profiles");
+				if (profileProperty != null && profileProperty.length() > 0) {
+					return asList(profiles).contains(profileProperty) ? FOUND : NOT_FOUND;
+				} else {
+					return ABSTAIN;
+				}
+			});
 			yamlFactory.setResources(new ByteArrayResource(s.getBytes()));
 			return yamlFactory.getObject();
 		};

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsSpringBootTest.java
@@ -76,7 +76,7 @@ public class ConfigMapsSpringBootTest {
 		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
 
 		HashMap<String,String> data = new HashMap<>();
-		data.put("bean.message","Hello ConfigMap, %s!");
+		data.put("bean.greeting","Hello ConfigMap, %s!");
 		server.expect().withPath("/api/v1/namespaces/test/configmaps/" + APPLICATION_NAME).andReturn(200, new ConfigMapBuilder()
 			.withNewMetadata().withName(APPLICATION_NAME).endMetadata()
 			.addToData(data)
@@ -108,7 +108,7 @@ public class ConfigMapsSpringBootTest {
 	public void testConfigMap() {
 		ConfigMap configmap = mockClient.configMaps().inNamespace("test").withName(APPLICATION_NAME).get();
 		HashMap<String,String> keys = (HashMap<String, String>) configmap.getData();
-		assertEquals(keys.get("bean.message"),"Hello ConfigMap, %s!");
+		assertEquals(keys.get("bean.greeting"),"Hello ConfigMap, %s!");
 	}
 
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfilesNoActiveProfileSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfilesNoActiveProfileSpringBootTest.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.restassured.RestAssured;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -36,7 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.kubernetes.config.example.App;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfilesNoActiveProfileSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfilesNoActiveProfileSpringBootTest.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.kubernetes.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -82,17 +83,22 @@ public class ConfigMapsWithProfilesNoActiveProfileSpringBootTest {
 			.always();
 	}
 
-	@Before
-	public void setUp() {
-		RestAssured.baseURI = String.format("http://localhost:%d/api/greeting", port);
-	}
-
 	@Test
 	public void testGreetingEndpoint() {
+		RestAssured.baseURI = String.format("http://localhost:%d/api/greeting", port);
 		when().get()
 			.then()
 			.statusCode(200)
-			.body("content", is("Hello ConfigMap prod, World!"));
+			.body("content", is("Hello ConfigMap default, World!"));
+	}
+
+	@Test
+	public void testFarewellEndpoint() {
+		RestAssured.baseURI = String.format("http://localhost:%d/api/farewell", port);
+		when().get()
+			.then()
+			.statusCode(200)
+			.body("content", is("Goodbye ConfigMap default, World!"));
 	}
 
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfilesSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfilesSpringBootTest.java
@@ -19,20 +19,16 @@ package org.springframework.cloud.kubernetes.config;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.springframework.cloud.kubernetes.config.ConfigMapTestUtil.*;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.restassured.RestAssured;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithoutProfilesSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithoutProfilesSpringBootTest.java
@@ -1,38 +1,17 @@
-/*
- * Copyright (C) 2016 to the original authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package org.springframework.cloud.kubernetes.config;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.springframework.cloud.kubernetes.config.ConfigMapTestUtil.*;
+import static org.springframework.cloud.kubernetes.config.ConfigMapTestUtil.readResourceFile;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.restassured.RestAssured;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,17 +21,14 @@ import org.springframework.cloud.kubernetes.config.example.App;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-/**
- * @author <a href="mailto:cmoullia@redhat.com">Charles Moulliard</a>
- */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-                classes = App.class,
-				properties = { "spring.application.name=configmap-with-profile-example",
-	           "spring.cloud.kubernetes.reload.enabled=false"}
-	           )
+	classes = App.class,
+	properties = { "spring.application.name=configmap-without-profile-example",
+		"spring.cloud.kubernetes.reload.enabled=false"}
+)
 @ActiveProfiles("development")
-public class ConfigMapsWithProfilesSpringBootTest {
+public class ConfigMapsWithoutProfilesSpringBootTest {
 
 	@ClassRule
 	public static KubernetesServer server = new KubernetesServer();
@@ -62,7 +38,7 @@ public class ConfigMapsWithProfilesSpringBootTest {
 	@Autowired(required = false)
 	Config config;
 
-	private static final String APPLICATION_NAME = "configmap-with-profile-example";
+	private static final String APPLICATION_NAME = "configmap-without-profile-example";
 
 	@Value("${local.server.port}")
 	private int port;
@@ -79,7 +55,7 @@ public class ConfigMapsWithProfilesSpringBootTest {
 		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
 
 		HashMap<String,String> data = new HashMap<>();
-		data.put("application.yml", readResourceFile("application-with-profiles.yaml"));
+		data.put("application.yml", readResourceFile("application-without-profiles.yaml"));
 		server.expect().withPath("/api/v1/namespaces/test/configmaps/" + APPLICATION_NAME).andReturn(200, new ConfigMapBuilder()
 			.withNewMetadata().withName(APPLICATION_NAME).endMetadata()
 			.addToData(data)
@@ -93,7 +69,7 @@ public class ConfigMapsWithProfilesSpringBootTest {
 		when().get()
 			.then()
 			.statusCode(200)
-			.body("content", is("Hello ConfigMap dev, World!"));
+			.body("content", is("Hello ConfigMap, World!"));
 	}
 
 	@Test
@@ -102,6 +78,6 @@ public class ConfigMapsWithProfilesSpringBootTest {
 		when().get()
 			.then()
 			.statusCode(200)
-			.body("content", is("Goodbye ConfigMap default, World!"));
+			.body("content", is("Goodbye ConfigMap, World!"));
 	}
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingController.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingController.java
@@ -37,7 +37,13 @@ public class GreetingController {
 
 	@RequestMapping("/api/greeting")
 	public Greeting greeting(@RequestParam(value="name", defaultValue="World") String name) {
-		String message = String.format(properties.getMessage(), name);
+		String message = String.format(properties.getGreeting(), name);
+		return new Greeting(message);
+	}
+
+	@RequestMapping("/api/farewell")
+	public Greeting farewell(@RequestParam(value="name", defaultValue="World") String name) {
+		String message = String.format(properties.getFarewell(), name);
 		return new Greeting(message);
 	}
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingProperties.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingProperties.java
@@ -24,14 +24,22 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "bean")
 public class GreetingProperties {
 
-	private String message = "Hello, %s!";
+	private String greeting = "Hello, %s!";
+	private String farewell = "Goodbye, %s!";
 
-	public String getMessage() {
-		return message;
+	public String getGreeting() {
+		return greeting;
 	}
 
-	public void setMessage(String message) {
-		this.message = message;
+	public void setGreeting(String greeting) {
+		this.greeting = greeting;
 	}
 
+	public String getFarewell() {
+		return farewell;
+	}
+
+	public void setFarewell(String farewell) {
+		this.farewell = farewell;
+	}
 }

--- a/spring-cloud-kubernetes-config/src/test/resources/application-with-profiles.yaml
+++ b/spring-cloud-kubernetes-config/src/test/resources/application-with-profiles.yaml
@@ -1,12 +1,13 @@
 bean:
-  message: "Hello ConfigMap default, %s!"
+  greeting: "Hello ConfigMap default, %s!"
+  farewell: "Goodbye ConfigMap default, %s!"
 ---
 spring:
   profiles: development
 bean:
-  message: "Hello ConfigMap dev, %s!"
+  greeting: "Hello ConfigMap dev, %s!"
 ---
 spring:
   profiles: production
 bean:
-  message: "Hello ConfigMap prod, %s!"
+  greeting: "Hello ConfigMap prod, %s!"

--- a/spring-cloud-kubernetes-config/src/test/resources/application-without-profiles.yaml
+++ b/spring-cloud-kubernetes-config/src/test/resources/application-without-profiles.yaml
@@ -1,0 +1,3 @@
+bean:
+  greeting: "Hello ConfigMap, %s!"
+  farewell: "Goodbye ConfigMap, %s!"


### PR DESCRIPTION
With the current implementation, any default properties (i.e. part of yaml docs that did not specify a "spring.profile" entry) would not be read. This caused unexpected behavior where "default" keys were not being read, and if NO document specified a "spring.profile" entry, the configmap would be completely ignored.

This new logic instead performs yaml merge inheritance between any yaml doc that has no "spring.profile" entry, as well as docs with the specific "profile" we have active
