### PR TITLE
KubernetesCatalogWatch endpoint based

### DIFF
--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfiguration.java
@@ -39,7 +39,7 @@ public class KubernetesDiscoveryClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(name = "spring.cloud.kubernetes.discovery.catalog-services-watch.enabled", matchIfMissing = true)
-	public KubernetesCatalogWatch kubernetesCatalogWatch(KubernetesDiscoveryClient client) {
+	public KubernetesCatalogWatch kubernetesCatalogWatch(KubernetesClient client) {
 		return new KubernetesCatalogWatch(client);
 	}
 }

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchTest.java
@@ -1,8 +1,14 @@
 package org.springframework.cloud.kubernetes.discovery;
 
+import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,10 +16,14 @@ import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static java.util.Arrays.stream;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 /**
@@ -23,10 +33,16 @@ import static org.mockito.Mockito.*;
 public class KubernetesCatalogWatchTest {
 
 	@Mock
-	private KubernetesDiscoveryClient kubernetesDiscoveryClient;
+	private KubernetesClient kubernetesClient;
 
 	@Mock
 	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Mock
+	private MixedOperation<Endpoints, EndpointsList, DoneableEndpoints, Resource<Endpoints, DoneableEndpoints>> endpointsOperation;
+
+	@Captor
+	private ArgumentCaptor<HeartbeatEvent> heartbeatEventArgumentCaptor;
 
 	@InjectMocks
 	private KubernetesCatalogWatch underTest;
@@ -37,10 +53,11 @@ public class KubernetesCatalogWatchTest {
 	}
 
 	@Test
-	public void testRandomOrder() throws Exception {
-		final List<String> services = Arrays.asList("api", "api", "other");
-		final List<String> shuffleServices = Arrays.asList("api", "other", "api");
-		when(kubernetesDiscoveryClient.getServices()).thenReturn(services);
+	public void testRandomOrderChangePods() throws Exception {
+		when(endpointsOperation.list())
+			.thenReturn(createSingleEndpointEndpointListByPodName("api-pod", "other-pod"))
+			.thenReturn(createSingleEndpointEndpointListByPodName("other-pod", "api-pod"));
+		when(kubernetesClient.endpoints()).thenReturn(endpointsOperation);
 
 		underTest.catalogServicesWatch();
 		// second execution on shuffleServices
@@ -48,4 +65,81 @@ public class KubernetesCatalogWatchTest {
 
 		verify(applicationEventPublisher).publishEvent(any(HeartbeatEvent.class));
 	}
+
+	@Test
+	public void testRandomOrderChangeServices() throws Exception {
+		when(endpointsOperation.list())
+			.thenReturn(createEndpointsListByServiceName("api-service", "other-service"))
+			.thenReturn(createEndpointsListByServiceName("other-service", "api-service"));
+		when(kubernetesClient.endpoints()).thenReturn(endpointsOperation);
+
+		underTest.catalogServicesWatch();
+		// second execution on shuffleServices
+		underTest.catalogServicesWatch();
+
+		verify(applicationEventPublisher).publishEvent(any(HeartbeatEvent.class));
+	}
+
+	@Test
+	public void testEventBody() throws Exception {
+		when(endpointsOperation.list())
+			.thenReturn(createSingleEndpointEndpointListByPodName("api-pod", "other-pod"));
+		when(kubernetesClient.endpoints()).thenReturn(endpointsOperation);
+
+		underTest.catalogServicesWatch();
+
+		verify(applicationEventPublisher).publishEvent(heartbeatEventArgumentCaptor.capture());
+
+		HeartbeatEvent event = heartbeatEventArgumentCaptor.getValue();
+		assertThat(event.getValue(), instanceOf(List.class));
+
+		List<String> expectedPodsList = Arrays.asList("api-pod", "other-pod");
+		assertEquals(expectedPodsList, event.getValue());
+	}
+
+
+	private EndpointsList createEndpointsListByServiceName(String... serviceNames) {
+		List<Endpoints> endpoints = stream(serviceNames)
+			.map(s -> createEndpointsByPodName(s + "-singlePodUniqueId"))
+			.collect(Collectors.toList());
+
+		EndpointsList endpointsList = new EndpointsList();
+		endpointsList.setItems(endpoints);
+		return endpointsList;
+	}
+
+	private EndpointsList createSingleEndpointEndpointListByPodName(String... podNames) {
+		Endpoints endpoints = new Endpoints();
+		endpoints.setSubsets(createSubsetsByPodName(podNames));
+
+		EndpointsList endpointsList = new EndpointsList();
+		endpointsList.setItems(Collections.singletonList(endpoints));
+		return endpointsList;
+	}
+
+
+	private Endpoints createEndpointsByPodName(String podName) {
+		Endpoints endpoints = new Endpoints();
+		endpoints.setSubsets(createSubsetsByPodName(podName));
+		return endpoints;
+	}
+
+
+	private List<EndpointSubset> createSubsetsByPodName(String... names) {
+		EndpointSubset endpointSubset = new EndpointSubset();
+		endpointSubset.setAddresses(createEndpointAddressByPodNames(names));
+		return Collections.singletonList(endpointSubset);
+	}
+
+	private List<EndpointAddress> createEndpointAddressByPodNames(String[] names) {
+		return stream(names).map(name -> {
+			ObjectReference podRef = new ObjectReference();
+			podRef.setName(name);
+			EndpointAddress endpointAddress = new EndpointAddress();
+			endpointAddress.setTargetRef(podRef);
+			return endpointAddress;
+		}).collect(Collectors.toList());
+	}
+
+
 }


### PR DESCRIPTION
Fix problem [https://github.com/spring-cloud-incubator/spring-cloud-kubernetes/issues/150#issuecomment-402499289](https://github.com/spring-cloud-incubator/spring-cloud-kubernetes/issues/150#issuecomment-402499289)


---
![91](https://user-images.githubusercontent.com/1370173/42319963-52c3a640-805c-11e8-8218-75c6e1a45c91.png)

org.springframework.cloud.client.ServiceInstance  Instance is a Pod and not Service.

Pod name is [unique](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)

---
P.S. Watch  resourceVersion  of EndpointsList not effective. Many false positives that do not affect the list of ServiceInstance.